### PR TITLE
[#4] [RND-342] remove an invalid testcases from odbc unittest

### DIFF
--- a/UnitTest/UnitTest/TestTransaction.cs
+++ b/UnitTest/UnitTest/TestTransaction.cs
@@ -189,10 +189,6 @@ namespace UnitTest
             Assert.IsTrue(tran.IsolationLevel == IsolationLevel.Serializable);
             tran.Commit();
 
-            tran = conn.BeginTransaction(IsolationLevel.ReadUncommitted);
-            Assert.IsTrue(tran.IsolationLevel == IsolationLevel.ReadUncommitted);
-            tran.Commit();
-
             tran = conn.BeginTransaction(IsolationLevel.RepeatableRead);
             Assert.IsTrue(tran.IsolationLevel == IsolationLevel.RepeatableRead);
             tran.Commit();


### PR DESCRIPTION
- "Read Uncommitted" isolation level is removed from CUBRID 10.0 release.
- However, it was not removed from the test case.