### PR TITLE
[#9] [RND-269] SQLDescribeCol() function should return SQL_LONGVARBINARY and SQL_LONGVARCHAR for BLOB and CLOB data type rather than SQL_C_DEFAULT.

### DIFF
--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -484,9 +484,13 @@ odbc_get_desc_field (ODBC_DESC * desc,
 	case SQL_DESC_CONCISE_TYPE:
 	  if (value_ptr != NULL)
 	    {
-	      if(record->concise_type == SQL_BLOB || record->concise_type == SQL_CLOB)
+	      if (record->concise_type == SQL_BLOB)
 	        {
-	          *(short *) value_ptr = SQL_BINARY;
+	          *(short *) value_ptr = SQL_LONGVARBINARY;
+	        }
+	      else if (record->concise_type == SQL_CLOB)
+	        {
+	          *(short *) value_ptr = SQL_LONGVARCHAR;
 	        }
 	      else
 	        {

--- a/odbc_type.c
+++ b/odbc_type.c
@@ -426,6 +426,9 @@ PRIVATE int odbc_is_valid_sql_verbose_type (short odbc_type);
 PRIVATE int odbc_is_valid_c_common_type (short c_type);
 PRIVATE int odbc_is_valid_sql_common_type (short sql_type);
 
+PRIVATE int odbc_is_valid_lob_type (short odbc_type);
+PRIVATE int odbc_is_valid_sql_lob_type (short sql_type);
+
 PRIVATE int odbc_is_valid_date_code (short code);
 PRIVATE int odbc_is_valid_internal_code (short code);
 
@@ -435,9 +438,9 @@ PUBLIC int
 odbc_is_valid_type (short odbc_type)
 {
   return (odbc_is_valid_concise_type (odbc_type) ||
-	  odbc_is_valid_verbose_type (odbc_type));
+	  odbc_is_valid_verbose_type (odbc_type) ||
+	  odbc_is_valid_lob_type (odbc_type));
 }
-
 
 PUBLIC int
 odbc_is_valid_code (short code)
@@ -2361,6 +2364,18 @@ odbc_is_valid_sql_common_type (short sql_type)
   int set_size = GET_SET_SIZE (sql_common_type_set);
 
   return seek_in_common_type_set (sql_common_type_set, set_size, sql_type);
+}
+
+PRIVATE int
+odbc_is_valid_lob_type (short odbc_type)
+{
+  return odbc_is_valid_sql_lob_type (odbc_type);
+}
+
+PRIVATE int
+odbc_is_valid_sql_lob_type (short sql_type)
+{
+  return ((sql_type == SQL_BLOB) || (sql_type == SQL_CLOB));
 }
 
 PRIVATE int


### PR DESCRIPTION
following is fixed database types
* BLOB
-- SQL_C_DEFAULT
-- (fixed) ---> SQL_LONGVARBINARY
* CLOB
-- SQL_C_DEFAULT
-- (fixed) ---> SQL_LONGVARCHAR