### PR TITLE
[#9] [RND-265] in the UNICODE version of cubrid_odbc.dll, SQLDescribeCol() function should return SQL_WCHAR instead of SQL_WVARCHAR for the CHAR(n) database type under utf-8 charset.

### DIFF
--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -1376,7 +1376,14 @@ odbc_set_ird (ODBC_STATEMENT * stmt,
 	    }
 	   else
 	    {
-              type = SQL_WVARCHAR;
+              if (type == SQL_CHAR)
+                {
+                  type = SQL_WCHAR;
+                }
+              else
+                {
+                  type = SQL_WVARCHAR;
+                }
 	    }
        }
      else


### PR DESCRIPTION
following is fixed database type:
* CHAR(n) database type
-- SQL_WVARCHAR
-- (fixed) ---> SQL_WCHAR