### PR TITLE
[APIS-759] To prevent application crash caused by health_checker thread, GET_MODULE_HANDLE_EX_FLAG_PIN flag was used when calling the GetModuleHandleEx function at DLL_PROCESS_ATTACH state in DllMain.

### DIFF
--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -66,10 +66,15 @@ PUBLIC HINSTANCE hInstance;
 BOOL WINAPI
 DllMain (HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
+  HMODULE hMd = NULL;
 
   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
     {
       cci_init ();
+      DisableThreadLibraryCalls (hModule);
+      GetModuleHandleEx (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+       (LPCTSTR)SQLDriverConnect,
+       &hMd);
     }
 
   // hInstance is declared at resource_proc.c


### PR DESCRIPTION
Description of code change:
1. DisableThreadLibraryCalls()
-- Disable the DllMain function call by threads created after loading cubrid_odbc.dll
2. GetModuleHandleEx() with GET_MODULE_HANDLE_EX_FLAG_PIN flag
-- Defer the timing of unloading cubrid_odbc.dll to the end of the process in order to prevent memory crash by health checker thread