### PR TITLE
[APIS-790] Invalid BufferLength in SQLGetDiagRecW(...) for wide char

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -280,7 +280,7 @@ SQLGetDiagRecW (SQLSMALLINT HandleType,
 
   if (TextLength)
    {
-     *TextLength = (SQLSMALLINT)out_length;
+     *TextLength = (SQLSMALLINT)(message_text_buffer_len * sizeof(wchar_t));
    }
 
   UT_FREE (message_text_buffer);


### PR DESCRIPTION
This is for a sub-task of APIS-788, [Improve the functions of ODBC, patch the bugs related to multi-byte character set.]

SQLGetDiagRecW(..., SQLSMALLINT * TextLength)  calls SQLGetDataRec to process the diagnostic records. But the TextLength is not set correctly in case that the SQLGetDataRec returns SUCESS_WITH_INFO.

The TextLength might be 0 in that case. This routine has to be fixed to process the diagnostic message correctly for wide character environment.