### PR TITLE
[APIS-791] SQLGetDiagRecW returns SQL State to S01000 for connection error.

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -270,7 +270,14 @@ SQLGetDiagRecW (SQLSMALLINT HandleType,
      UT_FREE (message_text_buffer);
      return ret;
    }
-                     
+
+  if (Sqlstate && sql_state)
+  {
+		int temp_buffer_length = MultiByteToWideChar (CP_ACP, 0, (LPCSTR) sql_state, strlen(sql_state), NULL, 0);
+
+		MultiByteToWideChar (CP_ACP, 0, (LPCSTR) sql_state, strlen(sql_state), Sqlstate, temp_buffer_length);
+  }
+  
   bytes_to_wide_char (message_text_buffer, 
                message_text_buffer_len, 
                &MessageText, 


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

Under the wide char environment, the SQLGetDiagW returns SQL State to "S01000" in connection error.
It might show the incorrect information to ODBC application when the connection error occurred.
