### PR TITLE
Apis 792

### DIFF
--- a/odbc_diag_record.c
+++ b/odbc_diag_record.c
@@ -511,12 +511,37 @@ odbc_get_diag_field (SQLSMALLINT handle_type,
 	case SQL_DIAG_CONNECTION_NAME:	/* yet not implemeted */
 	  if (diag_info_ptr && buffer_length > 0)
 	  {
+	    int connhd = -1;
+		int cci_ret = 0;
+	    T_CCI_ERROR cci_err_buf;
+
 		*((char *) diag_info_ptr) = '\0';
-		*string_length_ptr=0;
+		
+		if (handle_type == SQL_HANDLE_DBC)
+		{
+			connhd = ((ODBC_CONNECTION *) handle)->connhd;
+		}
+	    else if (handle_type == SQL_HANDLE_STMT)
+		{
+			connhd = ((ODBC_STATEMENT *) handle)->conn->connhd;
+		}
+
+		if (connhd >= 0)
+		{
+			cci_ret = cci_get_cas_info(connhd, (char *)diag_info_ptr, 32, &cci_err_buf);
+		}
+		if (connhd < 0 || cci_ret < 0)
+		{
+			*((char *) diag_info_ptr) = '\0';
+	        *string_length_ptr=0;
+		}
+		else *string_length_ptr = strlen((char *)diag_info_ptr);
+		
 		return ODBC_SUCCESS;
 	  }
-	  else
+	  else {
 		return SQL_SUCCESS_WITH_INFO;
+	  }
 
 	case SQL_DIAG_MESSAGE_TEXT:
 	  {

--- a/odbc_diag_record.c
+++ b/odbc_diag_record.c
@@ -509,39 +509,40 @@ odbc_get_diag_field (SQLSMALLINT handle_type,
 	  break;
 
 	case SQL_DIAG_CONNECTION_NAME:	/* yet not implemeted */
-	  if (diag_info_ptr && buffer_length > 0)
-	  {
-	    int connhd = -1;
-		int cci_ret = 0;
-	    T_CCI_ERROR cci_err_buf;
-
-		*((char *) diag_info_ptr) = '\0';
+      if (diag_info_ptr && buffer_length > 0)
+        {
+          int connhd = -1;
+          int cci_ret = 0;
+          T_CCI_ERROR cci_err_buf;
 		
-		if (handle_type == SQL_HANDLE_DBC)
-		{
-			connhd = ((ODBC_CONNECTION *) handle)->connhd;
-		}
-	    else if (handle_type == SQL_HANDLE_STMT)
-		{
-			connhd = ((ODBC_STATEMENT *) handle)->conn->connhd;
-		}
+          if (handle_type == SQL_HANDLE_DBC)
+            {
+              connhd = ((ODBC_CONNECTION *) handle)->connhd;
+            }
+          else if (handle_type == SQL_HANDLE_STMT)
+            {
+              connhd = ((ODBC_STATEMENT *) handle)->conn->connhd;
+            }
 
-		if (connhd >= 0)
-		{
-			cci_ret = cci_get_cas_info(connhd, (char *)diag_info_ptr, 32, &cci_err_buf);
-		}
-		if (connhd < 0 || cci_ret < 0)
-		{
-			*((char *) diag_info_ptr) = '\0';
-	        *string_length_ptr=0;
-		}
-		else *string_length_ptr = strlen((char *)diag_info_ptr);
-		
-		return ODBC_SUCCESS;
-	  }
-	  else {
-		return SQL_SUCCESS_WITH_INFO;
-	  }
+          if (connhd >= 0)
+            {
+              cci_ret = cci_get_cas_info(connhd, (char *)diag_info_ptr, 32, &cci_err_buf);
+            }
+          if (connhd < 0 || cci_ret < 0)
+            {
+              *((char *) diag_info_ptr) = '\0';
+              *string_length_ptr=0;
+            }
+		  else
+            {
+			  *string_length_ptr = strlen((char *)diag_info_ptr);
+            }
+            return ODBC_SUCCESS;
+          }
+        else
+          {
+             return SQL_SUCCESS_WITH_INFO;
+          }
 
 	case SQL_DIAG_MESSAGE_TEXT:
 	  {


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

It is needed to get the session information for DB connection during processing the transaction.
There's no method to get the session id and any related information of Cubrid ODBC connection.