### PR TITLE
[APIS-793] Increasing default column length for derived column

### DIFF
--- a/odbc_type.h
+++ b/odbc_type.h
@@ -36,7 +36,7 @@
 #include		"cas_cci.h"
 
 #define			MAX_CUBRID_CHAR_LEN			(1073741823)
-#define			DEFAULT_COL_PRECISION		(256)
+#define			DEFAULT_COL_PRECISION		(4*1024)
 
 #define			SQL_UNI_MONETARY		30
 #define			SQL_C_UNI_MONETARY		SQL_UNI_MONETARY


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

ODBC processing is completed by calling the related API twice  in case that the buffer length is less than needed length.

In special, derived column length is always returned to 0 from cci API calling. And in ODBC driver the length is replaced to DEFAILT_COL_PRECISION (=256).

This value 256 can be small to process the column length in once. 