### PR TITLE
[APIS-794] Processing multi-byte (utf-8) column name

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -405,7 +405,7 @@ SQLDescribeColW (SQLHSTMT hstmt, SQLUSMALLINT column,
      return ret;
    }
    
-  bytes_to_wide_char (name_buffer, name_buffer_len, &name, name_max, &out_length, NULL);
+  bytes_to_wide_char (name_buffer, name_buffer_len, &name, name_max, &out_length, "utf-8");
 
   if (name_len)
    {
@@ -1006,7 +1006,7 @@ SQLColAttributeW (SQLHSTMT StatementHandle,
         }
       if (CharacterAttribute && StringLength)
         {
-          bytes_to_wide_char (CharacterAttribute, *StringLength / 2, &wvalue, 0, NULL, NULL);
+          bytes_to_wide_char (CharacterAttribute, *StringLength / 2, &wvalue, 0, NULL, "utf-8");
           if(wvalue != NULL)
            {
              (void)memcpy ((char *)CharacterAttribute, (const char *)wvalue, *StringLength);


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

In common, the UTF-8 character set is converted to UNI-code by internal driver routine.
But the in case of column name, the routine has wrong code. As a result, the column name with UTF-8 code is not displayed in correct.