### PR TITLE
[APIS-795] Correct processing multi-bye binding in update query

### DIFF
--- a/odbc_type.c
+++ b/odbc_type.c
@@ -957,9 +957,12 @@ odbc_type_to_cci_u_type (short sql_type)
     {
 
     case SQL_CHAR:
+	case SQL_WCHAR:
       return CCI_U_TYPE_CHAR;
     case SQL_VARCHAR:
+	case SQL_WVARCHAR:
     case SQL_LONGVARCHAR:
+	case SQL_WLONGVARCHAR:
       return CCI_U_TYPE_STRING;
 
     case SQL_BINARY:

--- a/odbc_type.c
+++ b/odbc_type.c
@@ -957,12 +957,12 @@ odbc_type_to_cci_u_type (short sql_type)
     {
 
     case SQL_CHAR:
-	case SQL_WCHAR:
+    case SQL_WCHAR:
       return CCI_U_TYPE_CHAR;
     case SQL_VARCHAR:
-	case SQL_WVARCHAR:
+    case SQL_WVARCHAR:
     case SQL_LONGVARCHAR:
-	case SQL_WLONGVARCHAR:
+    case SQL_WLONGVARCHAR:
       return CCI_U_TYPE_STRING;
 
     case SQL_BINARY:


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

In binding parameters in query processing, its type is converted to a cci-valid type from the original type.
For example, the SQL_CHAR type is converted to CCI_U_TYPE_CHAR for further processing at server side.
But it's no converted to valid cci-type in case SQL_WCHAR and SQL_WVARCHAR as like wide character string.

