### PR TITLE
[APIS-796] Correct processing SQLCancel(...)

### DIFF
--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -235,7 +235,7 @@ SQLCancel (SQLHSTMT StatementHandle)
 
   rc = odbc_cancel (stmt_handle);
 
-  stmt_handle->canceled = 1;
+  stmt_handle->canceled = _TRUE_;
 
   DEBUG_TIMESTAMP (END_SQLCancel);
 
@@ -1045,7 +1045,7 @@ SQLGetData (SQLHSTMT StatementHandle,
   stmt_handle = (ODBC_STATEMENT *) StatementHandle;
   odbc_free_diag (stmt_handle->diag, RESET);
 
-  if (stmt_handle->canceled)
+  if (stmt_handle->canceled == _TRUE_)
     {
       ODBC_RETURN(rc, StatementHandle);
     }

--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -235,6 +235,8 @@ SQLCancel (SQLHSTMT StatementHandle)
 
   rc = odbc_cancel (stmt_handle);
 
+  stmt_handle->canceled = 1;
+
   DEBUG_TIMESTAMP (END_SQLCancel);
 
   ODBC_RETURN (rc, StatementHandle);
@@ -1042,6 +1044,11 @@ SQLGetData (SQLHSTMT StatementHandle,
 
   stmt_handle = (ODBC_STATEMENT *) StatementHandle;
   odbc_free_diag (stmt_handle->diag, RESET);
+
+  if (stmt_handle->canceled)
+    {
+      ODBC_RETURN(rc, StatementHandle);
+    }
 
   rc = odbc_get_data (stmt_handle, ColumnNumber,
 		      TargetType, TargetValue, BufferLength, StrLen_or_Ind);

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -141,6 +141,7 @@ odbc_alloc_statement (ODBC_CONNECTION * conn, ODBC_STATEMENT ** stmt_ptr)
       goto error;
     }
 
+  s->canceled = 0;
   s->handle_type = SQL_HANDLE_STMT;
   s->stmthd = 0;
   s->conn = NULL;
@@ -1860,10 +1861,10 @@ odbc_cancel (ODBC_STATEMENT * stmt)
     {
       /* CHECK : 이로 인해서 발생하는 현상은? */
       if (stmt->stmthd > 0)
-	{
-	  cci_close_req_handle (stmt->stmthd);
-	  stmt->stmthd = -1;
-	}
+        {
+          cci_cancel(stmt->conn->connhd);
+          stmt->stmthd = -1;
+        }
     }
 
   return ODBC_SUCCESS;

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -141,7 +141,7 @@ odbc_alloc_statement (ODBC_CONNECTION * conn, ODBC_STATEMENT ** stmt_ptr)
       goto error;
     }
 
-  s->canceled = 0;
+  s->canceled = _FALSE_;
   s->handle_type = SQL_HANDLE_STMT;
   s->stmthd = 0;
   s->conn = NULL;

--- a/odbc_statement.h
+++ b/odbc_statement.h
@@ -177,6 +177,7 @@ typedef struct st_odbc_statement
   unsigned short *attr_row_operation_ptr;	// 1
   unsigned long attr_simulate_cursor;	// 2
 
+  char canceled;
 
 
   // Descriptor section


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

In current ODBC driver, for a long query the response for SQLExecute(...) is delayed for a long time after calling  SQLCancel(...).
The reason is because the SQLCancel is not valid processing. The routine just sets the statement handle to -1 for current connection.
