### PR TITLE
[APIS-797] Processing to get the query-plan for any queries.

### DIFF
--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -793,6 +793,18 @@ SQLExecDirect (SQLHSTMT StatementHandle,
 
   stStatementText = UT_MAKE_STRING (StatementText, TextLength);
 
+  if (stricmp(StatementText, "@QP@") == 0)
+    {
+      stmt_handle->query_plan = CCI_EXEC_ONLY_QUERY_PLAN;
+      return ODBC_SUCCESS;
+    }
+  
+  if (stricmp(StatementText, "@QE@") == 0)
+    {
+      stmt_handle->query_plan = CCI_EXEC_ONLY_QUERY_PLAN | CCI_EXEC_QUERY_ALL;
+      return ODBC_SUCCESS;
+    }
+
   stmt_handle->is_prepared = _FALSE_;
 
   rc = odbc_prepare (stmt_handle, stStatementText);

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -148,6 +148,7 @@ odbc_alloc_statement (ODBC_CONNECTION * conn, ODBC_STATEMENT ** stmt_ptr)
   s->cursor = NULL;
   s->sql_text = NULL;
   s->is_prepared = _FALSE_;
+  s->query_plan = _FALSE_;
   memset (&s->revised_sql, 0, sizeof (s->revised_sql));
   s->result_type = NULL_RESULT;
   s->data_at_exec_state = STMT_NEED_NO_MORE_DATA;
@@ -2788,8 +2789,16 @@ get_flag_of_cci_prepare (ODBC_STATEMENT * stmt)
 PRIVATE char
 get_flag_of_cci_execute (ODBC_STATEMENT * stmt)
 {
+  char flag;
+
   if (stmt == NULL)
     return 0;
+
+  if (stmt->query_plan)
+    {
+      flag = stmt->query_plan;
+      return flag;
+    }
 
   if (stmt->attr_async_enable == SQL_ASYNC_ENABLE_ON)
     {

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -2789,15 +2789,12 @@ get_flag_of_cci_prepare (ODBC_STATEMENT * stmt)
 PRIVATE char
 get_flag_of_cci_execute (ODBC_STATEMENT * stmt)
 {
-  char flag;
-
   if (stmt == NULL)
     return 0;
 
   if (stmt->query_plan)
     {
-      flag = stmt->query_plan;
-      return flag;
+      return stmt->query_plan;
     }
 
   if (stmt->attr_async_enable == SQL_ASYNC_ENABLE_ON)

--- a/odbc_statement.h
+++ b/odbc_statement.h
@@ -150,7 +150,7 @@ typedef struct st_odbc_statement
   T_CCI_CUBRID_STMT stmt_type;
   PARAM_DATA param_data;	/* For data at exec */
   char is_prepared;		// SQLPrepare에 의해서만 prepare상태에 놓인다.
-
+  char query_plan;
 
   /* Supported attributes */
   unsigned long attr_metadata_id;	// Core


### PR DESCRIPTION
This is a sub-task APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

ODBC driver doesn't support to get the query-plan for any queries. In CUBRID ODBC driver doesn't also support this feature.
So, we need to implement this feature by meta-query concept. The meta-query string will be very short for convenient using.

