### PR TITLE
[APIS-798] Correct processing multi-byte for native query (SQLNativeSql)

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -321,12 +321,14 @@ SQLNativeSqlW (SQLHDBC hdbc, SQLWCHAR *in, SQLINTEGER in_len,
    memset (sql_text_buffer, 0 , out_max);
       
   ret = SQLNativeSql(hdbc,  sql_state,  sql_state_len,  sql_text_buffer,  out_max, out_len);
+  sql_state_len = *out_len;
+
   if (ret == ODBC_ERROR)
    {
      UT_FREE (sql_text_buffer);
      return ret;
    }
-  bytes_to_wide_char (sql_state, sql_state_len, &out, out_max, out_len, NULL);   
+  bytes_to_wide_char (sql_text_buffer, sql_state_len, &out, out_max, out_len, NULL);   
   UT_FREE (sql_text_buffer);
   return ret;
 }


### PR DESCRIPTION
This is a sub-task of APIS-788 [Improve the functions of ODBC, patch the bugs related to multi-byte character set]

SQLNativeSql interface is used to convert a query to Native Query but current driver doesn't process for multi-byte character set.
We need to correct the processing of SQLNativeSql for multi-byte character set.