### PR TITLE
[APIS-789] Upgrad build envrionment: compatibility for Legacy standard I/O Definition

### DIFF
--- a/odbc_util.c
+++ b/odbc_util.c
@@ -41,6 +41,10 @@
 
 static int is_korean (unsigned char ch);
 
+#pragma comment(lib, "legacy_stdio_definitions.lib")
+
+
+
 /************************************************************************
 * name:  InitStr
 * arguments: 


### PR DESCRIPTION
Standard I/O has to be used for compatibility with the older versions.
