### PR TITLE
[APIS-799] Correct processing of string length for SUCCESS_WITH_INFO

### DIFF
--- a/odbc_util.c
+++ b/odbc_util.c
@@ -1033,14 +1033,7 @@ str_value_assign (const char *in_value,
 
   if (val_len_ptr != NULL)
     {
-      if (rc == ODBC_SUCCESS_WITH_INFO)
-        {
-          *val_len_ptr = ODBC_STRLEN_IND (in_value);
-        }
-      else
-        {
-          *val_len_ptr = ODBC_STRLEN_IND (out_buf);
-        }
+      *val_len_ptr = ODBC_STRLEN_IND (in_value);
     }
 
   return rc;

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -1033,7 +1033,7 @@ str_value_assign (const char *in_value,
 
   if (val_len_ptr != NULL)
     {
-      if (rc != ODBC_SUCCESS_WITH_INFO)
+      if (rc == ODBC_SUCCESS_WITH_INFO)
         {
           *val_len_ptr = ODBC_STRLEN_IND (in_value);
         }


### PR DESCRIPTION
We correct the common string processing routine "str_value_assign". Currently, the routine returns incorrect string length in case of SUCESS_WITH_INFO.

It returns the length of buffer length for output data, it has to correct to return input string length.