### PR TITLE
[APIS-800] Correct processing for multi-byte to wide-char and vice-vesa.

### DIFF
--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -1371,37 +1371,37 @@ odbc_set_ird (ODBC_STATEMENT * stmt,
   if(IS_STRING_TYPE (type) || IS_BINARY_TYPE (type))
    { 
  #ifdef CUBRID_ODBC_UNICODE
-    if((_stricmp (stmt->conn->charset, "utf-8") == 0) || (_stricmp(stmt->conn->charset, "euc-kr") == 0))
-       {
-	   if(type == SQL_LONGVARCHAR || precision > 4000)
-	    {
+      if((_stricmp (stmt->conn->charset, "utf-8") == 0) || (_stricmp(stmt->conn->charset, "euc-kr") == 0))
+        {
+	      if(type == SQL_LONGVARCHAR || precision > 4000)
+	        {
               type = SQL_WLONGVARCHAR;
               octet_length = display_size = MAX_CUBRID_CHAR_LEN;
-	    }
-	   else
-	    {
-              if (type == SQL_CHAR)
-                {
-                  type = SQL_WCHAR;
-                }
-              else
-                {
-                  type = SQL_WVARCHAR;
-                }
-	    }
+	        }
+	      else
+	        {
+          if (type == SQL_CHAR)
+            {
+              type = SQL_WCHAR;
+            }
+          else
+            {
+              type = SQL_WVARCHAR;
+            }
+	      }
        }
      else
        {
-           if(type == SQL_LONGVARCHAR)
-           {
-              octet_length = display_size = MAX_CUBRID_CHAR_LEN;
-            }       
-       }
-#else
          if(type == SQL_LONGVARCHAR)
            {
-              octet_length = display_size = MAX_CUBRID_CHAR_LEN;
-            }
+             octet_length = display_size = MAX_CUBRID_CHAR_LEN;
+           }       
+       }
+#else
+     if(type == SQL_LONGVARCHAR)
+       {
+         octet_length = display_size = MAX_CUBRID_CHAR_LEN;
+       }
 #endif
    }
   // set ird field

--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -1371,7 +1371,7 @@ odbc_set_ird (ODBC_STATEMENT * stmt,
   if(IS_STRING_TYPE (type) || IS_BINARY_TYPE (type))
    { 
  #ifdef CUBRID_ODBC_UNICODE
-    if((_stricmp (stmt->conn->charset, "utf-8") == 0))
+    if((_stricmp (stmt->conn->charset, "utf-8") == 0) || (_stricmp(stmt->conn->charset, "euc-kr") == 0))
        {
 	   if(type == SQL_LONGVARCHAR || precision > 4000)
 	    {

--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -1373,22 +1373,22 @@ odbc_set_ird (ODBC_STATEMENT * stmt,
  #ifdef CUBRID_ODBC_UNICODE
       if((_stricmp (stmt->conn->charset, "utf-8") == 0) || (_stricmp(stmt->conn->charset, "euc-kr") == 0))
         {
-	      if(type == SQL_LONGVARCHAR || precision > 4000)
-	        {
+          if(type == SQL_LONGVARCHAR || precision > 4000)
+            {
               type = SQL_WLONGVARCHAR;
               octet_length = display_size = MAX_CUBRID_CHAR_LEN;
-	        }
-	      else
-	        {
-          if (type == SQL_CHAR)
-            {
-              type = SQL_WCHAR;
             }
           else
             {
-              type = SQL_WVARCHAR;
+              if (type == SQL_CHAR)
+                {
+                  type = SQL_WCHAR;
+                }
+              else
+                {
+                  type = SQL_WVARCHAR;
+                }
             }
-	      }
        }
      else
        {

--- a/odbc_result.c
+++ b/odbc_result.c
@@ -611,7 +611,7 @@ odbc_get_data (ODBC_STATEMENT * stmt,
 
         rc =
           get_wide_char_result(query_plan, strlen(query_plan), (wchar_t **)&bound_ptr,
-            (int)buffer_length, &temp_length, "utf-8");
+            (int)buffer_length, &temp_length, stmt->conn->charset);
 
         *str_ind_ptr = temp_length;
 

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -39,6 +39,10 @@
 #define		UNIT_MEMORY_SIZE		256
 #define		STK_SIZE        100
 
+#ifndef CP_EUC_KR
+#define CP_EUC_KR 51949 
+#endif
+
 static int is_korean (unsigned char ch);
 
 #pragma comment(lib, "legacy_stdio_definitions.lib")
@@ -1320,9 +1324,9 @@ encode_string_to_charset(wchar_t *str, int size, char **target, int* out_length,
       {
         wincode = CP_UTF8;
       }
-	else if (_stricmp(charset, "euc-kr") == 0)
+    else if (_stricmp(charset, "euc-kr") == 0)
       {
-        wincode = 51949;
+        wincode = CP_EUC_KR;
       }
 
     nLength = WideCharToMultiByte(wincode, 0, str, -1, NULL, 0, NULL, NULL);
@@ -1422,7 +1426,7 @@ bytes_to_wide_char (char *str, int size, wchar_t **buffer, int buffer_length, in
     }
   else if (_stricmp(characterset, "euc-kr") == 0)
     {
-      wincode = 51949;
+      wincode = CP_EUC_KR;
     }
 
   if(str == NULL || buffer == NULL)
@@ -1477,7 +1481,7 @@ get_wide_char_result (char *str, int size, wchar_t **buffer, int buffer_length, 
     }
   else if (_stricmp(characterset, "euc-kr") == 0)
     {
-	  wincode = 51949;
+      wincode = CP_EUC_KR;
     }
 
   if(str == NULL || buffer == NULL)

--- a/unicode.c
+++ b/unicode.c
@@ -315,14 +315,14 @@ SQLNativeSqlW (SQLHDBC hdbc, SQLWCHAR *in, SQLINTEGER in_len,
   RETCODE ret = ODBC_ERROR;
   SQLCHAR *sql_state, *sql_text_buffer = NULL;
   int sql_state_len;  
-  ODBC_CONNECTION * ConnectionHandle = (ODBC_CONNECTION *) hdbc;
+  ODBC_CONNECTION * conn = (ODBC_CONNECTION *) hdbc;
   
   OutputDebugString ("SQLNativeSqlW called.\n");
-  ret = wide_char_to_bytes (in, in_len, &sql_state,  &sql_state_len, ConnectionHandle->charset);
+  ret = wide_char_to_bytes (in, in_len, &sql_state,  &sql_state_len, conn->charset);
   sql_text_buffer = UT_ALLOC (out_max);
   if (sql_text_buffer == NULL && out_max > 0)
     {
-      odbc_set_diag (ConnectionHandle->diag, "HY001", 0, "malloc failed");
+      odbc_set_diag (conn->diag, "HY001", 0, "malloc failed");
       return ODBC_ERROR;
     }
    memset (sql_text_buffer, 0 , out_max);
@@ -335,7 +335,7 @@ SQLNativeSqlW (SQLHDBC hdbc, SQLWCHAR *in, SQLINTEGER in_len,
      UT_FREE (sql_text_buffer);
      return ret;
    }
-  bytes_to_wide_char (sql_text_buffer, sql_state_len, &out, out_max, out_len, ConnectionHandle->charset);
+  bytes_to_wide_char (sql_text_buffer, sql_state_len, &out, out_max, out_len, conn->charset);
   UT_FREE (sql_text_buffer);
   return ret;
 }


### PR DESCRIPTION
Current driver only processes multi-byte data utf-8 for conversion to wide-char and conversion to vice-versa.

We also need to consider on euc-kr (2-byte code) data.