### PR TITLE
[APIS-816] Fix SQLExecDirect bug for more than 67 bind parameters

### DIFF
--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -1232,7 +1232,11 @@ odbc_prepare (ODBC_STATEMENT * stmt, char *statement_text)
 						 oid_param_pos,
 						 &stmt->revised_sql.
 						 oid_param_val);
-
+  if (stmt->revised_sql.oid_param_num < 0)
+    {
+	odbc_set_diag(stmt->diag, "HY000", 0, "Too many bind Parameters used.");
+	return ODBC_ERROR;
+    }
   flag_cci_prepare = get_flag_of_cci_prepare (stmt);
   cci_rc =
     cci_prepare (stmt->conn->connhd, stmt->revised_sql.sql_text,

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -38,7 +38,7 @@
 
 #define		UNIT_MEMORY_SIZE		256
 #define		STK_SIZE        100
-#define           PARAM_POS_SIZE  256
+#define           PARAM_POS_SIZE  1024
 
 #ifndef CP_EUC_KR
 #define CP_EUC_KR 51949 

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -38,7 +38,7 @@
 
 #define		UNIT_MEMORY_SIZE		256
 #define		STK_SIZE        100
-#define           PARAM_POS_SIZE  512
+#define           PARAM_POS_SIZE  256
 
 #ifndef CP_EUC_KR
 #define CP_EUC_KR 51949 
@@ -447,7 +447,7 @@ ut_make_binary (const char *src, int length)
 PUBLIC int
 add_element_to_setstring(char *setstring, char *element, int size)
 {
-    if (setstring == NULL || element == NULL || size < 0 || (strlen(setstring) + strlen(element)) >= size)
+    if (setstring == NULL || element == NULL || (strlen(setstring) + strlen(element)) >= size)
     {
       return -1;
     }
@@ -953,7 +953,7 @@ replace_oid (char *sql_text, char **org_param_pos_pt,
 		}
 
 	      sprintf (buf, "%s", oid_buf);
-		if (add_element_to_setstring(oid_param_val, buf, PARAM_POS_SIZE) < 0)
+		if (add_element_to_setstring(oid_param_val, buf, PARAM_POS_SIZE*4) < 0)
 		  {
 		    return -1;
 		  }

--- a/odbc_util.h
+++ b/odbc_util.h
@@ -206,7 +206,7 @@ PUBLIC void ut_free_bstr  (WCHAR *ptr);
 PUBLIC int sqlwcharlen(const WCHAR *wstr);
 PUBLIC int element_from_setstring (char **current, char *buf);
 
-PUBLIC int add_element_to_setstring (char *setstring, char *element);
+PUBLIC int add_element_to_setstring (char *setstring, char *element, int size);
 
 PUBLIC char *odbc_trim (char *str);
 PUBLIC RETCODE str_value_assign (const char *in_value,

--- a/odbc_util.h
+++ b/odbc_util.h
@@ -121,7 +121,7 @@
 			fclose(fp);                         \
 		} while (0)
 
-#define DEBUG_FILE_KEY          "d:\\temp\\time_log.txt"
+#define DEBUG_FILE_KEY          "c:\\temp\\time_log.txt"
 #define DEBUG_TIMESTAMP(value)
 
                 #define DEBUG_TIMESTAMP(value)                          \
@@ -206,7 +206,7 @@ PUBLIC void ut_free_bstr  (WCHAR *ptr);
 PUBLIC int sqlwcharlen(const WCHAR *wstr);
 PUBLIC int element_from_setstring (char **current, char *buf);
 
-PUBLIC void add_element_to_setstring (char *setstring, char *element);
+PUBLIC int add_element_to_setstring (char *setstring, char *element);
 
 PUBLIC char *odbc_trim (char *str);
 PUBLIC RETCODE str_value_assign (const char *in_value,


### PR DESCRIPTION
### situation
- while replace positional parameters to a **setstring** in replace_oid () at odbc_util.c
- it uses 256 bytes buffer to contain intermediate result, 
for example, char org_param_pos[256];
- with 68 positional parameters for binding, it require more than 261 bytes and 
- add_element_to_setstring () at odbc_util.c do not have buffer overflow for 'char array'
- We did
### works done
1. Extends buffer to 1024, approoximately handle 256 columns binding
2. Check this 1024 limit is exceeds, if so return error thru 'odbc_set_diag ()'