### PR TITLE
[APIS-875] Fix nullable param bug in the function SQLDescribeCol

### DIFF
--- a/odbc_descriptor.c
+++ b/odbc_descriptor.c
@@ -1466,6 +1466,8 @@ odbc_set_ird (ODBC_STATEMENT * stmt,
 		       (SQLPOINTER) scale, 0, 1);
   odbc_set_desc_field (stmt->ird, column_number, SQL_DESC_DISPLAY_SIZE,
 		       (SQLPOINTER) display_size, 0, 1);
+  odbc_set_desc_field (stmt->ird, column_number, SQL_DESC_NULLABLE,
+		       (SQLPOINTER) nullable, 0, 1);
 
   searchable = odbc_type_searchable (type);
   odbc_set_desc_field (stmt->ird, column_number, SQL_DESC_SEARCHABLE,


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-875

Purpose
Fix bug in SQLDescribeCol (), return value of **NullablePtr**.

Implementation
N/A

Remarks
* CCI provide a column attribute for null is permitted on a column, however, ODBC missed to put the information to the ODBC Descriptor, **ird**.
* odbc_set_ird () set the ird value and have to change (ODBC_RECORD *) record ->nullable by the argument it received, but it missed it.
* Hence ird->record[i]->nullable is **SQL_NULLABLE_UNKNOWN** which is set by odbc_alloc_record () as an initial value.