### PR TITLE
[APIS-876] Bind null as a valid parameter

### DIFF
--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -1383,7 +1383,7 @@ odbc_execute (ODBC_STATEMENT * stmt)
 	    odbc_get_desc_field (stmt->ipd, i, SQL_DESC_LENGTH,
 				 &(desc_info.length), 0, NULL);
 
-	  if (ind_ptr != NULL && *ind_ptr == SQL_NULL_DATA)
+	  if (value_ptr == NULL || ind_ptr != NULL && *ind_ptr == SQL_NULL_DATA)
 	    {
 	      cci_rc =
 		cci_bind_param (stmt->stmthd, RevisedParamPos, a_type, NULL,


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-876

Purpose
* Bind null value during SQLExecute ()
* Problem originally reported in Linked Server interconnection, with trying to insert null value into a column

Implementation
N/A