### PR TITLE
[APIS-848] support Oracle DB-Link

### DIFF
--- a/odbc_result.c
+++ b/odbc_result.c
@@ -1070,7 +1070,7 @@ get_bind_info (ODBC_STATEMENT * stmt,
   if (stmt->ard->bind_type == SQL_BIND_BY_COLUMN)
     {
       (*(long long *)bound_ptr) += offset_size + row_index * (*buffer_length);
-      (*(long long *)strlen_ind_ptr) += offset_size + row_index * sizeof (long);
+      (*(long long *)strlen_ind_ptr) += offset_size + row_index * sizeof (long *);
     }
   else
     {

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -1337,7 +1337,7 @@ encode_string_to_charset(wchar_t *str, int size, char **target, int* out_length,
          num_wchars = size;
       }
 
-    if (charset == NULL || _stricmp(charset, "utf-8") == 0)
+    if (charset == NULL || _stricmp(charset, "utf-8") == 0 || _stricmp(charset, "utf8") == 0)
       {
         wincode = CP_UTF8;
       }
@@ -1438,7 +1438,7 @@ bytes_to_wide_char (char *str, int size, wchar_t **buffer, int buffer_length, in
   wchar_t* temp_buffer = *buffer;
   int temp_buffer_length = buffer_length;
   
-  if (characterset == NULL || _stricmp(characterset, "utf-8") == 0)
+  if (characterset == NULL || _stricmp(characterset, "utf-8") == 0 || _stricmp(characterset, "utf8") == 0)
     {
       wincode = CP_UTF8;
     }
@@ -1493,7 +1493,7 @@ get_wide_char_result (char *str, int size, wchar_t **buffer, int buffer_length, 
   int temp_buffer_length = buffer_length;
   int rc = ODBC_SUCCESS;
   
-  if (characterset == NULL || _stricmp (characterset, "utf-8") == 0)
+  if (characterset == NULL || _stricmp (characterset, "utf-8") == 0 || _stricmp (characterset, "utf8") == 0)
     {
       wincode = CP_UTF8;
     }

--- a/unicode.c
+++ b/unicode.c
@@ -423,7 +423,7 @@ SQLDescribeColW (SQLHSTMT hstmt, SQLUSMALLINT column,
 
   if (name_len)
    {
-     *name_len = (SQLSMALLINT)out_length;
+     *name_len = (SQLSMALLINT) (out_length / sizeof (wchar_t));
    }
 
   UT_FREE (name_buffer);     


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-848

**Purpose**
- to support connecting CUBRID using oracle DB Link, in turn, thru Oracle **dg4odbc**.

**Implementation**
N/A

**Remarks**
dg4odbc, initcubrid.ora for UNICODE
```
# This is a sample agent init file that contains the HS parameters that are
# needed for the Database Gateway for ODBC

#
# HS init parameters
#
HS_FDS_CONNECT_INFO = cubrid
HS_FDS_TRACE_LEVEL = 255
HS_LANGUAGE=KOREAN_KOREA.UTF8
HS_NLS_NCHAR=KO16MSWIN949
#
HS_FDS_REPORT_REAL_AS_DOUBLE=true
HS_FDS_SQLLEN_INTERPRETATION=64
HS_TRANSACTION_MODEL = SINGLE_SITE
#
HS_FDS_FETCH_ROWS=1
# Environment variables required for the non-Oracle system
#
#set <envvar>=<value>
```
Windows Oracle charset
```
SQL> select * from nls_database_parameters where parameter like '%CHAR%' ;

PARAMETER
------------------------------
VALUE
--------------------------------------------------------------------------------
NLS_NUMERIC_CHARACTERS
.,

NLS_CHARACTERSET
KO16MSWIN949

NLS_NCHAR_CONV_EXCP
FALSE


PARAMETER
------------------------------
VALUE
--------------------------------------------------------------------------------
NLS_NCHAR_CHARACTERSET
UTF8


SQL>
```