### PR TITLE
[APIS-904] Add connection error handling

### DIFF
--- a/odbc_connection.c
+++ b/odbc_connection.c
@@ -818,8 +818,8 @@ odbc_connect_new (ODBC_CONNECTION * conn,
   pt = charset == NULL ? "" : charset;
   conn->charset = UT_MAKE_STRING (pt, -1);
 
-  pt = autocommit == NULL ? "on" : autocommit;
-  if (_stricmp (autocommit, "on") == 0)
+  pt = autocommit == NULL ? "off" : autocommit;
+  if (_stricmp (pt, "on") == 0)
     {
       conn->attr_autocommit = SQL_AUTOCOMMIT_ON;
     }

--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -604,6 +604,8 @@ SQLDriverConnect (HDBC hdbc,
 	  port = ptPort ? atoi (ptPort) : 0;
 	  fetch_size = ptFetchSize ? atoi (ptFetchSize) : 0;
 
+	  ptAutoCommit = ptAutoCommit == NULL ? "off" : ptAutoCommit;
+
 	  rc = odbc_connect_new (hdbc, ptFileDSN, ptDBName, ptUser,
 				 ptPWD, ptServer, port, fetch_size, ptCharSet, ptAutoCommit, ConnStrIn);
 	}
@@ -615,6 +617,7 @@ SQLDriverConnect (HDBC hdbc,
 	  ptPort = element_value_by_key (ConnStrIn, KEYWORD_PORT);
 	  ptFetchSize = element_value_by_key (ConnStrIn, KEYWORD_FETCH_SIZE);
 	  ptCharSet = element_value_by_key (ConnStrIn, KEYWORD_CHARSET);
+	  ptAutoCommit = element_value_by_key (ConnStrIn, KEYWORD_AUTOCOMMIT);
 
 	  get_dsn_info (ptDSN, db_name, sizeof (db_name), NULL, 0,
 			NULL, 0, server, sizeof (server), &port, &fetch_size,

--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -604,8 +604,6 @@ SQLDriverConnect (HDBC hdbc,
 	  port = ptPort ? atoi (ptPort) : 0;
 	  fetch_size = ptFetchSize ? atoi (ptFetchSize) : 0;
 
-	  ptAutoCommit = ptAutoCommit == NULL ? "off" : ptAutoCommit;
-
 	  rc = odbc_connect_new (hdbc, ptFileDSN, ptDBName, ptUser,
 				 ptPWD, ptServer, port, fetch_size, ptCharSet, ptAutoCommit, ConnStrIn);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-904

Purpose
You can connect to the server using SQLDriverConnect().
The connection method can be used using DSN and connection url. At this time, if autocommit is not set, it may be null. The cause of the connection error is that autocommit, which is null, was compared with a string.
Exception handling is required when autocommit is null.

Implementation
N/A

Remarks
N/A