### PR TITLE
[APIS-943] SQLColumnsW/SQLForeignKeysW does not work properly

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -540,6 +540,51 @@ namespace UnitTestCPP
 
 		}
 
+		TEST_METHOD(APIS_943_SQLCOLUMNSW)
+		{
+#define NUM_COLS_PARTICIPANT 5
+			SQLHENV         hEnv;
+			SQLHDBC         hDbc;
+			SQLHSTMT        hstmt;
+			CHAR			msg[512];
+			SQLINTEGER		retcode;
+			SQLSMALLINT		num_cols = 0;
+			SQLLEN			indicator;
+
+			retcode = SQLAllocEnv(&hEnv);
+			retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
+			retcode = SQLAllocConnect(hEnv, &hDbc);
+			retcode = SQLDriverConnectW(hDbc, NULL, L"DRIVER=CUBRID Driver Unicode;server=test-db-server;port=33000;uid=public;pwd=;db_name=demodb;charset=utf-8;", SQL_NTS, NULL, 0, NULL, SQL_DRIVER_NOPROMPT);
+			Assert::AreNotEqual((int)retcode, SQL_ERROR);
+			retcode = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hstmt);
+
+			retcode = SQLColumnsW(hstmt, NULL, 0, NULL, 0, L"participant", SQL_NTS, NULL, 0);
+
+			while (SQL_SUCCEEDED(retcode = SQLFetch(hstmt))) {
+				SQLCHAR buf[255];
+
+				memset(buf, 0, sizeof(buf));
+
+				retcode = SQLGetData(hstmt, 4, SQL_C_CHAR, buf, sizeof(buf), &indicator);
+
+				if (SQL_SUCCEEDED(retcode)) {
+					sprintf(msg, "COLUMN [%d]: %s", 1+num_cols++, buf);
+					Logger::WriteMessage(msg);
+				}
+			}
+
+			sprintf(msg, "Num Cols = %d", num_cols);
+			Logger::WriteMessage(msg);
+
+			Assert::AreNotEqual((int) num_cols, 0);
+
+			retcode = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+			retcode = SQLDisconnect(hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
+
+		}
+
 		TEST_METHOD(APIS_794_QueryPlanMultiByte)
 		{
 			RETCODE retcode;

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -539,10 +539,8 @@ namespace UnitTestCPP
 			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
 
 		}
-
 		TEST_METHOD(APIS_943_SQLCOLUMNSW)
 		{
-#define NUM_COLS_PARTICIPANT 5
 			SQLHENV         hEnv;
 			SQLHDBC         hDbc;
 			SQLHSTMT        hstmt;
@@ -582,9 +580,50 @@ namespace UnitTestCPP
 			retcode = SQLDisconnect(hDbc);
 			retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
 			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
+		}
+		TEST_METHOD(APIS_943_FOREIGNKEYSW)
+		{
+			SQLHENV         hEnv;
+			SQLHDBC         hDbc;
+			SQLHSTMT        hstmt;
+			CHAR			msg[512];
+			SQLINTEGER		retcode;
+			SQLSMALLINT		num_tables = 0;
+			SQLLEN			indicator;
+
+			retcode = SQLAllocEnv(&hEnv);
+			retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
+			retcode = SQLAllocConnect(hEnv, &hDbc);
+			retcode = SQLDriverConnectW(hDbc, NULL, L"DRIVER=CUBRID Driver Unicode;server=test-db-server;port=33000;uid=public;pwd=;db_name=demodb;charset=utf-8;", SQL_NTS, NULL, 0, NULL, SQL_DRIVER_NOPROMPT);
+			Assert::AreNotEqual((int)retcode, SQL_ERROR);
+			retcode = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hstmt);
+
+			retcode = SQLForeignKeysW (hstmt, NULL, 0, NULL, 0, L"olympic", SQL_NTS, NULL, 0, NULL, 0, NULL, 0);
+
+			while (SQL_SUCCEEDED(retcode = SQLFetch(hstmt))) {
+				SQLCHAR buf[255];
+
+				memset(buf, 0, sizeof(buf));
+
+				retcode = SQLGetData(hstmt, 7, SQL_C_CHAR, buf, sizeof(buf), &indicator);
+
+				if (SQL_SUCCEEDED(retcode)) {
+					sprintf(msg, "FK Table [%d]: %s", 1 + num_tables++, buf);
+					Logger::WriteMessage(msg);
+				}
+			}
+
+			sprintf(msg, "Num FK Tables = %d", num_tables);
+			Logger::WriteMessage(msg);
+
+			Assert::AreNotEqual((int)num_tables, 0);
+
+			retcode = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+			retcode = SQLDisconnect(hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
 
 		}
-
 		TEST_METHOD(APIS_794_QueryPlanMultiByte)
 		{
 			RETCODE retcode;

--- a/unicode.c
+++ b/unicode.c
@@ -371,6 +371,11 @@ SQLColumnsW (SQLHSTMT hstmt,
   wide_char_to_bytes (table, table_len, &cb_table,  &cb_table_len, stmt_handle->conn->charset);
   wide_char_to_bytes (column, column_len, &cb_column,  &cb_column_len, stmt_handle->conn->charset);
 
+  if (cb_column_len == 0)
+    {
+	  NA_FREE(cb_column);
+    }
+
   ret = SQLColumns (hstmt,
                     cb_catalog, cb_catalog_len,
                     cb_schema, cb_schema_len,
@@ -462,6 +467,16 @@ SQLForeignKeysW (SQLHSTMT hstmt,
   wide_char_to_bytes (fk_catalog, fk_catalog_len, &cb_fk_catalog, &cb_fk_catalog_len, stmt->conn->charset);
   wide_char_to_bytes (fk_schema, fk_schema_len, &cb_fk_schema, &cb_fk_schema_len, stmt->conn->charset);
   wide_char_to_bytes (fk_table, fk_table_len, &cb_fk_table, &cb_fk_table_len, stmt->conn->charset);
+
+  if (cb_pk_table_len == 0)
+  {
+	  NA_FREE(cb_pk_table);
+  }
+
+  if (cb_fk_table_len == 0)
+  {
+	  NA_FREE(cb_fk_table);
+  }
         
   ret = SQLForeignKeys(hstmt, 
                                        cb_pk_catalog, cb_pk_catalog_len, cb_pk_schema, cb_pk_schema_len,


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-943

**Purpose**
* To fix bug, SQLColumnsW, SQLForeignKeysW

**Implementation**
**ASIS**
```
retcode = SQLColumns (hstmt, NULL, 0, NULL, 0, "code", 4, "", 0);
..
retcode = SQLForeignKeysW (hstmt, NULL, 0, NULL, 0, L"olympic", SQL_NTS, NULL, 0, NULL, 0, "", 0);
```

**TOBE**
```
retcode = SQLColumns (hstmt, NULL, 0, NULL, 0, "code", 4, NULL, 0);
...
retcode = SQLForeignKeysW (hstmt, NULL, 0, NULL, 0, L"olympic", SQL_NTS, NULL, 0, NULL, 0, NULL, 0);
```

**Remarks**