### PR TITLE
[APIS-987] enable bind more than 128 parameters

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1107,15 +1107,15 @@ namespace UnitTestCPP
 				"?, ?"
 				")";
 
-#define	ARRAY_SZ	8
-#define	STR_SZ		20
-#define COL_SIZE	20
+#define	ARRAY_SZ	100
+#define COL_SIZE	80
 #define NUM_COL		130
 
 			SQLWCHAR query_create[4096];
 			int nArraySize(ARRAY_SZ);
-			int BUFLEN (40);
-			SQLWCHAR tbldata[NUM_COL+1][ARRAY_SZ][COL_SIZE];
+			int BUFLEN(COL_SIZE*sizeof(SQLWCHAR));
+			SQLWCHAR tbldata[ARRAY_SZ][COL_SIZE];
+			SQLWCHAR tbldata2[ARRAY_SZ][COL_SIZE];
 			SQLUSMALLINT	ParamStatusArray[ARRAY_SZ];
 			SQLLEN			ParamsProcessed[ARRAY_SZ];
 			SQLLEN pIndicator[NUM_COL];
@@ -1162,15 +1162,25 @@ namespace UnitTestCPP
 			retcode = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAM_STATUS_PTR, ParamStatusArray, 0);
 			retcode = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAMS_PROCESSED_PTR, ParamsProcessed, 0);
 
-			for (int i = 1; i <= NUM_COL; i++)
+			for (int i = 0; i < ARRAY_SZ; i++)
 			{
-				for (int j = 0; j < ARRAY_SZ; j++)
-				  wsprintf(tbldata[i][j], L"Data %d-%d", i, j);
-				retcode = SQLBindParameter(hStmt, i, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR,
-					COL_SIZE, 0, tbldata[i], BUFLEN, &pIndicator[i]);
+					wsprintf(tbldata[i], L"큐브리드 ODBC Data %d", i);
+					wsprintf(tbldata2[i], L"큐브리드 ODBC Data_2 %d", i);
 			}
 
-			retcode = SQLExecute(hStmt);
+			for (int i = 1; i < NUM_COL; i++)
+			{
+				retcode = SQLBindParameter(hStmt, i+1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR,
+					COL_SIZE, 0, &tbldata[0], BUFLEN, &pIndicator[i]);
+			}
+			retcode = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR,
+				COL_SIZE, 0, tbldata2, BUFLEN, &pIndicator[0]);
+
+			for (int i = 1; i < 3; i++)
+			{
+				retcode = SQLExecute(hStmt);
+				retcode = SQLEndTran(SQL_HANDLE_ENV, hEnv, SQL_COMMIT);
+			}
 
 			if (retcode != SQL_SUCCESS) {
 				SQLINTEGER i = 0, NativeError;

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -911,8 +911,6 @@ namespace UnitTestCPP
 			SQLFreeHandle(SQL_HANDLE_ENV, env);
 		}
 
-
-
 		TEST_METHOD(APIS_901_QueryPlan)
 		{
 			RETCODE retcode;

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1124,6 +1124,8 @@ namespace UnitTestCPP
 			SWORD plm_pcbErrorMsg = 0;
 			RETCODE retcode(0);
 
+			int NUM_LOOP(10);  // 100 * NUM_LOOP rows will be inserted, to measure throughput
+
 			retcode = SQLAllocEnv(&hEnv);
 			retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
 			retcode = SQLAllocConnect(hEnv, &hDbc);
@@ -1176,7 +1178,7 @@ namespace UnitTestCPP
 			retcode = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR,
 				COL_SIZE, 0, tbldata2, BUFLEN, &pIndicator[0]);
 
-			for (int i = 1; i < 3; i++)
+			for (int i = 1; i < NUM_LOOP; i++)
 			{
 				retcode = SQLExecute(hStmt);
 				retcode = SQLEndTran(SQL_HANDLE_ENV, hEnv, SQL_COMMIT);

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -905,8 +905,8 @@ replace_oid (char *sql_text, char **org_param_pos_pt,
   char buf[126];
   char *pt;
   char *pt_tmp;
-  char current_param_pos = 0;
-  char oid_param_num = 0;
+  int current_param_pos = 0;
+  int oid_param_num = 0;
 
   org_param_pos[0] = '\0';
   oid_param_pos[0] = '\0';


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-987

**Purpose**
* To enable bind more than 128 positional parameters

**Implementation**

**Remarks**
* @mhoh3963 give me a hint for 'char' type value, thanks.
* When SQLPrepare () is executed, replace_oid () is called to pre-process bind parameters from SQLText
* It parses the SQLText, creates the position of the original positional parameter as a string in the form below, and stores it in **stmt->revised_sql.org_param_pos**:
 1;;2;;3;;4;;5;;6;;7;;8
* In SQLExecute (), on the contrary, each string is converted to an integer.
* Problem is, replace_oid () uses 'char' type variable to keep and increment index as folling code snippet:
```
int
replace_oid (...)
{
...
char current_param_pos = 0;
char oid_param_num = 0;
...
  ++current_param_pos;
  sprintf (buf, "%d", current_param_pos);
...
}
```
* As a result, processed string for original position will be following style:
 1;;2;;3;; ... ;;127;;-128;;-127;;