### PR TITLE
[APIS-1039] fix IDCANCEL undefined error for the Linux

### DIFF
--- a/odbc_interface.c
+++ b/odbc_interface.c
@@ -813,12 +813,14 @@ SQLDriverConnect (HDBC hdbc,
 	  strcpy (dsn_item.omit_schema, ptOmitSchema);
 	}
 
+#if defined (_WINDOWS)
       dlgrc = DialogBoxParam (hInstance, (LPCTSTR) IDD_CONFIGDSN, hWnd,
 			      ConfigDSNDlgProc, (LPARAM) & dsn_item);
       if (dlgrc == IDCANCEL)
 	{
 	  return SQL_NO_DATA;
 	}
+#endif
 
       sprintf (buf, "%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s;%s=%s",
 	       KEYWORD_DRIVER, ptDriver,


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1039

**Description**
* exclude code related with IDCANCEL for the Linux ODBC

**Remarks**
* this is because the fixes/modification to CUBRID ODBC after the Linux ODBC commit did not take Linux into account.
* The cause of this error is that two PRs were merged with a time difference. And the merge of Linux ODBC code is not well known to the public.
* we should be aware that ongoing revisions to ODBC will need to take Linux into account as well.
* thanks @vimkim , for detecting errors.