### PR TITLE
[APIS-1048] use table privileges query by version

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -617,6 +617,50 @@ namespace UnitTestCPP
 			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
 		}
 
+		TEST_METHOD(APIS_1048_SQLTablePrivileges_by_version)
+		{
+			/*
+			 * run this test case for
+			 *  1. CUBRID versions CUBRID 11.3 or lower
+			 *  2. CUBRID version 11.4 or higher
+			 */
+
+			SQLHENV         hEnv;
+			SQLHDBC         hDbc;
+			SQLHSTMT        hstmt;
+			SQLINTEGER		retcode;
+			SQLWCHAR		*table_name = L"TEST_TBL1";
+			SQLWCHAR		*user = L"PUBLIC";
+			SQLWCHAR		query[512];
+
+			retcode = SQLAllocEnv(&hEnv);
+			retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
+			retcode = SQLAllocConnect(hEnv, &hDbc);
+			retcode = SQLDriverConnectW(hDbc, NULL, L"DRIVER=CUBRID Driver Unicode;server=test-db-server;port=33000;uid=public;pwd=;db_name=demodb;charset=utf-8;", SQL_NTS, NULL, 0, NULL, SQL_DRIVER_NOPROMPT);
+			Assert::AreNotEqual((int)retcode, SQL_ERROR);
+			retcode = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hstmt);
+
+			wsprintf(query, L"DROP TABLE IF EXISTS %s", table_name);
+			retcode = SQLExecDirect(hstmt, query, SQL_NTS);
+
+			wsprintf(query, L"CREATE TABLE %s (col1 int)", table_name);
+			retcode = SQLExecDirect(hstmt, query, SQL_NTS);
+
+			Assert::AreNotEqual((int)retcode, SQL_ERROR);
+
+			retcode = SQLTablePrivileges(hstmt,
+				NULL, 0,
+				user, SQL_NTS,
+				table_name, SQL_NTS);
+
+			Assert::AreNotEqual((int)retcode, SQL_ERROR);
+
+			retcode = SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+			retcode = SQLDisconnect(hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
+			retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
+		}
+
 		TEST_METHOD(APIS_1049_Lowercase_tablename_for_catalog_qry)
 		{
 			SQLHENV         hEnv;

--- a/odbc_catalog.c
+++ b/odbc_catalog.c
@@ -533,7 +533,7 @@ PRIVATE void free_procedure_columns_node (ST_LIST * node);
 PRIVATE int retrieve_table_from_db_class (int cci_connection,
 					  char *table_name, T_CCI_ERROR *error);
 PRIVATE int schema_info_table_privileges (int cci_connection,
-					  int *cci_request, char *table_name, T_CCI_ERROR *error);
+					  int *cci_request, char *table_name, int db_ver, T_CCI_ERROR *error);
 PRIVATE int schema_info_procedures (int cci_connection, int *cci_request,
 				    char *proc_name, T_CCI_ERROR *error);
 PRIVATE int schema_info_procedure_columns (int cci_connection,
@@ -1005,6 +1005,7 @@ odbc_table_privileges (ODBC_STATEMENT * stmt, char *catalog_name,
 {
   int cci_retval = 0;
   int cci_request = 0;
+  int db_ver;
 	T_CCI_ERROR cci_error;
 
   char err_msg[SQL_MAX_MESSAGE_LENGTH + 1];
@@ -1024,9 +1025,14 @@ odbc_table_privileges (ODBC_STATEMENT * stmt, char *catalog_name,
       goto cci_error;
     }
 
+  if (stmt && stmt->conn)
+  {
+	  db_ver = connected_db_ver(stmt->conn->db_ver);
+  }
+
   if ((cci_retval = schema_info_table_privileges (stmt->conn->connhd,
 						  &cci_request,
-						  table_name, &cci_error)) < 0)
+						  table_name, db_ver, &cci_error)) < 0)
     {
       goto cci_error;
     }
@@ -3919,15 +3925,24 @@ retrieve_table_from_db_class (int cci_connection, char *table_name, T_CCI_ERROR 
 
 PRIVATE int
 schema_info_table_privileges (int cci_connection, int *cci_request,
-			      char *table_name, T_CCI_ERROR *error)
+			      char *table_name, int db_ver, T_CCI_ERROR *error)
 {
-  char *sql_statment =
+  char *sql_statment_default =
+   "SELECT "
+      "object_name, grantor_name, grantee_name, auth_type, is_grantable "
+   "FROM " "db_auth " "WHERE " "object_name = ?";
+  char *sql_statment_before_1103 =
     "SELECT "
-    "class_name, grantor_name, grantee_name, auth_type, is_grantable "
+      "class_name, grantor_name, grantee_name, auth_type, is_grantable "
     "FROM " "db_auth " "WHERE " "class_name = ?";
+  char *sql_statment = sql_statment_default;
 
   char *param_list[] = { table_name };
 
+  if (db_ver < 1104)
+    {
+	  sql_statment = *sql_statment_before_1103;
+    }
   return sql_execute (cci_connection, cci_request, sql_statment, param_list,
 		      1, error);
 }

--- a/odbc_catalog.c
+++ b/odbc_catalog.c
@@ -3941,7 +3941,7 @@ schema_info_table_privileges (int cci_connection, int *cci_request,
 
   if (db_ver < 1104)
     {
-      sql_statment = *sql_statment_before_1103;
+      sql_statment = sql_statment_before_1103;
     }
   return sql_execute (cci_connection, cci_request, sql_statment, param_list,
 		      1, error);

--- a/odbc_catalog.c
+++ b/odbc_catalog.c
@@ -1006,7 +1006,7 @@ odbc_table_privileges (ODBC_STATEMENT * stmt, char *catalog_name,
   int cci_retval = 0;
   int cci_request = 0;
   int db_ver;
-	T_CCI_ERROR cci_error;
+  T_CCI_ERROR cci_error;
 
   char err_msg[SQL_MAX_MESSAGE_LENGTH + 1];
 
@@ -1026,9 +1026,9 @@ odbc_table_privileges (ODBC_STATEMENT * stmt, char *catalog_name,
     }
 
   if (stmt && stmt->conn)
-  {
-	  db_ver = connected_db_ver(stmt->conn->db_ver);
-  }
+    {
+      db_ver = connected_db_ver(stmt->conn->db_ver);
+    }
 
   if ((cci_retval = schema_info_table_privileges (stmt->conn->connhd,
 						  &cci_request,
@@ -3928,9 +3928,9 @@ schema_info_table_privileges (int cci_connection, int *cci_request,
 			      char *table_name, int db_ver, T_CCI_ERROR *error)
 {
   char *sql_statment_default =
-   "SELECT "
+    "SELECT "
       "object_name, grantor_name, grantee_name, auth_type, is_grantable "
-   "FROM " "db_auth " "WHERE " "object_name = ?";
+    "FROM " "db_auth " "WHERE " "object_name = ?";
   char *sql_statment_before_1103 =
     "SELECT "
       "class_name, grantor_name, grantee_name, auth_type, is_grantable "
@@ -3941,7 +3941,7 @@ schema_info_table_privileges (int cci_connection, int *cci_request,
 
   if (db_ver < 1104)
     {
-	  sql_statment = *sql_statment_before_1103;
+      sql_statment = *sql_statment_before_1103;
     }
   return sql_execute (cci_connection, cci_request, sql_statment, param_list,
 		      1, error);

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -1672,21 +1672,21 @@ remove_owner_name (char *tablename)
 PUBLIC int
 connected_db_ver(const char *version_string)
 {
-	char *p;
-	int vers = -1;
+  char *p;
+  int vers = -1;
 
-	if (version_string == NULL || strlen(version_string) == 0)
-	{
-		return SQL_ERROR;
-	}
+  if (version_string == NULL || strlen(version_string) == 0)
+    {
+      return SQL_ERROR;
+    }
 
-	vers = atoi(version_string) * 100;
+  vers = atoi(version_string) * 100;
 
-	p = strchr(version_string, '.');
-	if (p)
-	{
-		vers += atoi(p + 1);
-	}
+  p = strchr(version_string, '.');
+  if (p)
+    {
+      vers += atoi(p + 1);
+    }
 
-	return vers;
+  return vers;
 }

--- a/odbc_util.c
+++ b/odbc_util.c
@@ -1668,3 +1668,25 @@ remove_owner_name (char *tablename)
 
   return ret;
 }
+
+PUBLIC int
+connected_db_ver(const char *version_string)
+{
+	char *p;
+	int vers = -1;
+
+	if (version_string == NULL || strlen(version_string) == 0)
+	{
+		return SQL_ERROR;
+	}
+
+	vers = atoi(version_string) * 100;
+
+	p = strchr(version_string, '.');
+	if (p)
+	{
+		vers += atoi(p + 1);
+	}
+
+	return vers;
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1048

**Description**
  * SQLTablePrivileges ()를 위한 query를 연결된 서버에 따라 변경
  * ASIS:
    SELECT
      **class_name**, grantor_name, grantee_name, auth_type, is_grantable
    FROM db_auth WHERE **class_name** = ?;
---
  * TOBE CASE 1 (연결된 DB Server version이 **11.3 이하**인 경우):
    SELECT
      class_name, grantor_name, grantee_name, auth_type, is_grantable
    FROM db_auth WHERE class_name = ?;
  * TOBE CASE 2 (연결된 DB Server version이 **11.4 이상**인 경우):
    SELECT
      **object_name**, grantor_name, grantee_name, auth_type, is_grantable
    FROM db_auth WHERE **object_name** = ?;
