### PR TITLE
[APIS-1059] Prepare loop problem when using ODBC in PHP and PDO

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1490,5 +1490,44 @@ public:
       retcode = SQLFreeHandle (SQL_HANDLE_DBC, hDbc);
       retcode = SQLFreeHandle (SQL_HANDLE_ENV, hEnv);
     }
+
+    TEST_METHOD(APIS_1059_SQLFreeStmt_And_SQLCloseCursor)
+    {
+	SQLHENV		hEnv;
+	SQLHDBC		hDbc;
+	SQLHSTMT	hStmt;
+
+	RETCODE retcode(0);
+	CHAR msg[512];
+	WCHAR wmsg[512];
+
+	retcode = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &hEnv);
+	retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
+	retcode = SQLAllocHandle(SQL_HANDLE_DBC, hEnv, &hDbc);
+	retcode = SQLConnect(hDbc, L"CUBRID Driver Unicode", SQL_NTS, L"dba", SQL_NTS, L"", SQL_NTS);
+	Assert::AreNotEqual((int)retcode, SQL_ERROR);
+	retcode = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+
+	retcode = SQLPrepare(hStmt, (SQLWCHAR *)(wchar_t *)L"INSERT INTO apis1053(id, name) VALUES(?, ?)", SQL_NTS);
+
+	retcode = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, 0, 0, NULL);
+	retcode = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, 255, 0, L"test", 0, NULL);
+	retcode = SQLExecute(hStmt);
+	Assert::AreNotEqual((int)retcode, SQL_ERROR);
+	retcode = SQLTransact(hEnv, hDbc, SQL_COMMIT);
+
+	retcode = SQLFreeStmt(hStmt, SQL_CLOSE);
+	Assert::AreNotEqual((int)retcode, SQL_ERROR);
+	retcode = SQLCloseCursor(hStmt);
+	Assert::AreEqual((int)retcode, SQL_ERROR);
+	SQLWCHAR Sqlstate[1024] = { 0, };
+	retcode = SQLGetDiagRec(SQL_HANDLE_STMT, hStmt, 1, Sqlstate, NULL, NULL, NULL, NULL);
+	Assert::AreNotEqual((int)retcode, SQL_ERROR);
+	wsprintf(wmsg, L"Sqlstate %s", Sqlstate);
+	Assert::AreEqual(Sqlstate, L"HY000");
+	retcode = SQLDisconnect(hDbc);
+	retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
+	retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
+    }
   };
 }

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1491,43 +1491,43 @@ public:
       retcode = SQLFreeHandle (SQL_HANDLE_ENV, hEnv);
     }
 
-    TEST_METHOD(APIS_1059_SQLFreeStmt_And_SQLCloseCursor)
+    TEST_METHOD (APIS_1059_SQLFreeStmt_And_SQLCloseCursor)
     {
-	SQLHENV		hEnv;
-	SQLHDBC		hDbc;
-	SQLHSTMT	hStmt;
+      SQLHENV		hEnv;
+      SQLHDBC		hDbc;
+      SQLHSTMT	hStmt;
 
-	RETCODE retcode(0);
-	CHAR msg[512];
-	WCHAR wmsg[512];
+      RETCODE retcode (0);
+      CHAR msg[512];
+      WCHAR wmsg[512];
 
-	retcode = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &hEnv);
-	retcode = SQLSetEnvAttr(hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
-	retcode = SQLAllocHandle(SQL_HANDLE_DBC, hEnv, &hDbc);
-	retcode = SQLConnect(hDbc, L"CUBRID Driver Unicode", SQL_NTS, L"dba", SQL_NTS, L"", SQL_NTS);
-	Assert::AreNotEqual((int)retcode, SQL_ERROR);
-	retcode = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+      retcode = SQLAllocHandle (SQL_HANDLE_ENV, SQL_NULL_HANDLE, &hEnv);
+      retcode = SQLSetEnvAttr (hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
+      retcode = SQLAllocHandle (SQL_HANDLE_DBC, hEnv, &hDbc);
+      retcode = SQLConnect (hDbc, L"CUBRID Driver Unicode", SQL_NTS, L"dba", SQL_NTS, L"", SQL_NTS);
+      Assert::AreNotEqual ((int)retcode, SQL_ERROR);
+      retcode = SQLAllocHandle (SQL_HANDLE_STMT, hDbc, &hStmt);
 
-	retcode = SQLPrepare(hStmt, (SQLWCHAR *)(wchar_t *)L"INSERT INTO apis1053(id, name) VALUES(?, ?)", SQL_NTS);
+      retcode = SQLPrepare (hStmt, (SQLWCHAR *) (wchar_t *)L"INSERT INTO apis1053(id, name) VALUES(?, ?)", SQL_NTS);
 
-	retcode = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, 0, 0, NULL);
-	retcode = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, 255, 0, L"test", 0, NULL);
-	retcode = SQLExecute(hStmt);
-	Assert::AreNotEqual((int)retcode, SQL_ERROR);
-	retcode = SQLTransact(hEnv, hDbc, SQL_COMMIT);
+      retcode = SQLBindParameter (hStmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, 0, 0, NULL);
+      retcode = SQLBindParameter (hStmt, 2, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, 255, 0, L"test", 0, NULL);
+      retcode = SQLExecute (hStmt);
+      Assert::AreNotEqual ((int)retcode, SQL_ERROR);
+      retcode = SQLTransact (hEnv, hDbc, SQL_COMMIT);
 
-	retcode = SQLFreeStmt(hStmt, SQL_CLOSE);
-	Assert::AreNotEqual((int)retcode, SQL_ERROR);
-	retcode = SQLCloseCursor(hStmt);
-	Assert::AreEqual((int)retcode, SQL_ERROR);
-	SQLWCHAR Sqlstate[1024] = { 0, };
-	retcode = SQLGetDiagRec(SQL_HANDLE_STMT, hStmt, 1, Sqlstate, NULL, NULL, NULL, NULL);
-	Assert::AreNotEqual((int)retcode, SQL_ERROR);
-	wsprintf(wmsg, L"Sqlstate %s", Sqlstate);
-	Assert::AreEqual(Sqlstate, L"HY000");
-	retcode = SQLDisconnect(hDbc);
-	retcode = SQLFreeHandle(SQL_HANDLE_DBC, hDbc);
-	retcode = SQLFreeHandle(SQL_HANDLE_ENV, hEnv);
+      retcode = SQLFreeStmt (hStmt, SQL_CLOSE);
+      Assert::AreNotEqual ((int)retcode, SQL_ERROR);
+      retcode = SQLCloseCursor (hStmt);
+      Assert::AreEqual ((int)retcode, SQL_ERROR);
+      SQLWCHAR Sqlstate[1024] = { 0, };
+      retcode = SQLGetDiagRec (SQL_HANDLE_STMT, hStmt, 1, Sqlstate, NULL, NULL, NULL, NULL);
+      Assert::AreNotEqual ((int)retcode, SQL_ERROR);
+      wsprintf (wmsg, L"Sqlstate %s", Sqlstate);
+      Assert::AreEqual (Sqlstate, L"HY000");
+      retcode = SQLDisconnect (hDbc);
+      retcode = SQLFreeHandle (SQL_HANDLE_DBC, hDbc);
+      retcode = SQLFreeHandle (SQL_HANDLE_ENV, hEnv);
     }
   };
 }

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1508,8 +1508,8 @@ public:
       Assert::AreNotEqual ((int)retcode, SQL_ERROR);
       retcode = SQLAllocHandle (SQL_HANDLE_STMT, hDbc, &hStmt);
 
-      retcode = SQLExecDirect(hStmt, L"DROP TABLE IF EXISTS apis1053", SQL_NTS);
-      retcode = SQLExecDirect(hStmt, L"CREATE TABLE apis1053 (id INT, name VARCHAR)", SQL_NTS);
+      retcode = SQLExecDirect (hStmt, L"DROP TABLE IF EXISTS apis1053", SQL_NTS);
+      retcode = SQLExecDirect (hStmt, L"CREATE TABLE apis1053 (id INT, name VARCHAR)", SQL_NTS);
       retcode = SQLPrepare (hStmt, (SQLWCHAR *) (wchar_t *)L"INSERT INTO apis1053(id, name) VALUES(?, ?)", SQL_NTS);
 
       retcode = SQLBindParameter (hStmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, 0, 0, NULL);

--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1508,6 +1508,8 @@ public:
       Assert::AreNotEqual ((int)retcode, SQL_ERROR);
       retcode = SQLAllocHandle (SQL_HANDLE_STMT, hDbc, &hStmt);
 
+      retcode = SQLExecDirect(hStmt, L"DROP TABLE IF EXISTS apis1053", SQL_NTS);
+      retcode = SQLExecDirect(hStmt, L"CREATE TABLE apis1053 (id INT, name VARCHAR)", SQL_NTS);
       retcode = SQLPrepare (hStmt, (SQLWCHAR *) (wchar_t *)L"INSERT INTO apis1053(id, name) VALUES(?, ?)", SQL_NTS);
 
       retcode = SQLBindParameter (hStmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, 0, 0, NULL);

--- a/odbc_env.c
+++ b/odbc_env.c
@@ -349,7 +349,7 @@ connection_end_tran (ODBC_CONNECTION *conn, short completion_type)
   // delete all open cursor
   for (stmt = conn->statements; stmt; stmt = stmt->next)
     {
-      odbc_close_cursor (stmt);
+      odbc_close_statement (stmt);
     }
 
   return ODBC_SUCCESS;

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -232,6 +232,7 @@ odbc_reset_statement (ODBC_STATEMENT *stmt, unsigned short option)
     case SQL_CLOSE:
       rc = odbc_close_cursor (stmt);
       break;
+
     case SQL_UNBIND:
       reset_descriptor (stmt->ard);
       stmt->ird->rows_processed_ptr = NULL;
@@ -286,7 +287,7 @@ odbc_free_statement (ODBC_STATEMENT *stmt)
 	      stmt->conn->statements = stmt->next;
 	    }
 	}
-      odbc_close_cursor (stmt);
+      odbc_close_statement (stmt);
     }
 
 
@@ -1824,11 +1825,42 @@ odbc_put_data (ODBC_STATEMENT *stmt, void *data_ptr, SQLLEN strlen_or_ind)
 * name: odbc_close_cursor
 * arguments:
 * returns/side-effects:
-* description:
+* description: 
 * NOTE:
 ************************************************************************/
 PUBLIC RETCODE
 odbc_close_cursor (ODBC_STATEMENT *stmt)
+{
+  T_CCI_ERROR cci_err_buf;
+  int cci_rc;
+  if (stmt->stmthd > 0)
+    {
+      cci_fetch_buffer_clear(stmt->stmthd);
+      cci_rc = cci_close_query_result(stmt->stmthd, &cci_err_buf);
+      if (cci_rc != CCI_ER_NO_ERROR)
+        {
+          odbc_set_diag_by_cci (stmt->diag, cci_rc, &cci_err_buf);
+          return ODBC_ERROR;
+        }
+
+      if (stmt->result_type != TYPE_INFO)
+	{
+	  odbc_auto_commit (stmt->conn);
+	}
+    }
+  reset_result_set (stmt);
+  return ODBC_SUCCESS;
+}
+
+/************************************************************************
+* name: odbc_close_statement
+* arguments:
+* returns/side-effects:
+* description:
+* NOTE:
+************************************************************************/
+PUBLIC RETCODE
+odbc_close_statement (ODBC_STATEMENT *stmt)
 {
   if (stmt->stmthd > 0)
     {

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -1825,7 +1825,7 @@ odbc_put_data (ODBC_STATEMENT *stmt, void *data_ptr, SQLLEN strlen_or_ind)
 * name: odbc_close_cursor
 * arguments:
 * returns/side-effects:
-* description: 
+* description:
 * NOTE:
 ************************************************************************/
 PUBLIC RETCODE
@@ -1835,13 +1835,13 @@ odbc_close_cursor (ODBC_STATEMENT *stmt)
   int cci_rc;
   if (stmt->stmthd > 0)
     {
-      cci_fetch_buffer_clear(stmt->stmthd);
-      cci_rc = cci_close_query_result(stmt->stmthd, &cci_err_buf);
+      cci_fetch_buffer_clear (stmt->stmthd);
+      cci_rc = cci_close_query_result (stmt->stmthd, &cci_err_buf);
       if (cci_rc != CCI_ER_NO_ERROR)
-        {
-          odbc_set_diag_by_cci (stmt->diag, cci_rc, &cci_err_buf);
-          return ODBC_ERROR;
-        }
+	{
+	  odbc_set_diag_by_cci (stmt->diag, cci_rc, &cci_err_buf);
+	  return ODBC_ERROR;
+	}
 
       if (stmt->result_type != TYPE_INFO)
 	{

--- a/odbc_statement.h
+++ b/odbc_statement.h
@@ -1,30 +1,30 @@
 /*
-* Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution. 
+* Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
 *
-* Redistribution and use in source and binary forms, with or without modification, 
-* are permitted provided that the following conditions are met: 
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
 *
-* - Redistributions of source code must retain the above copyright notice, 
-*   this list of conditions and the following disclaimer. 
+* - Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
 *
-* - Redistributions in binary form must reproduce the above copyright notice, 
-*   this list of conditions and the following disclaimer in the documentation 
-*   and/or other materials provided with the distribution. 
+* - Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
 *
-* - Neither the name of the <ORGANIZATION> nor the names of its contributors 
-*   may be used to endorse or promote products derived from this software without 
-*   specific prior written permission. 
+* - Neither the name of the <ORGANIZATION> nor the names of its contributors
+*   may be used to endorse or promote products derived from this software without
+*   specific prior written permission.
 *
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
-* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-* OF SUCH DAMAGE. 
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
 *
 */
 
@@ -87,11 +87,11 @@ typedef struct tagCATALOG_RESULT
 *   remain_length : 남은 data의 length, 문제는 remain_length가 0이라고 해서
 *     SQL_NO_DATA를 return할 수 었다.  empty string에 대해서 buffer length가 0이면
 *     예외 상황이 발생한다.  이를 막기 위해서 도입한게 fetch_status이다.
-*   fetch_status :  
+*   fetch_status :
 *       최초의 function call에서 SQL_NO_DATA가 발생할 수 없으며, SQL_SUCCESS_WITH_INFO
 *       다음에 SQL_NO_DATA로 건너 뛸 수 없다. 이것을 이용해서 저번 return status를
 *       저장해서 buffer length가 0에 대해서 SQL_NO_DATA를 return할 건지 결정한다.
-*         
+*
 *         ->    SQL_SUCCESS_WITH_INFO
 *
 *         ->    SQL_SUCCESS
@@ -141,7 +141,7 @@ typedef struct st_odbc_statement
          * update가 반영된 row 수
          * row_number - currunt row position */
   unsigned long current_tpl_pos;  /* result set에서 cursor의 위치,
-           * attr_row_number와 의미상 같다. 
+           * attr_row_number와 의미상 같다.
            * 0 Befor start, -1 After end */
 
   // param number는 column number와는 달리 ipd의 record개수가 아니다.
@@ -157,8 +157,8 @@ typedef struct st_odbc_statement
   unsigned long attr_cursor_scrollable; // 1
   unsigned long attr_cursor_type; // core, 2
   unsigned long attr_async_enable;  // 1, 2
-  unsigned long attr_use_bookmark;  /* 2    
-           * bookmark가 ok인 경우 
+  unsigned long attr_use_bookmark;  /* 2
+           * bookmark가 ok인 경우
            * prepare시 0번 record를 추가로
            * 생성한다. */
 
@@ -194,58 +194,58 @@ typedef struct st_odbc_statement
 } ODBC_STATEMENT;
 
 PUBLIC RETCODE odbc_alloc_statement (struct st_odbc_connection *conn,
-             ODBC_STATEMENT ** stmt_ptr);
-PUBLIC RETCODE odbc_free_statement (ODBC_STATEMENT * stmt);
-PUBLIC RETCODE odbc_reset_statement (ODBC_STATEMENT * stmt,
-             unsigned short option);
-PUBLIC RETCODE odbc_set_stmt_attr (ODBC_STATEMENT * stmt,
-           long attribute,
-           void *valueptr,
-           long stringlength, short is_driver);
+				     ODBC_STATEMENT **stmt_ptr);
+PUBLIC RETCODE odbc_free_statement (ODBC_STATEMENT *stmt);
+PUBLIC RETCODE odbc_reset_statement (ODBC_STATEMENT *stmt,
+				     unsigned short option);
+PUBLIC RETCODE odbc_set_stmt_attr (ODBC_STATEMENT *stmt,
+				   long attribute,
+				   void *valueptr,
+				   long stringlength, short is_driver);
 #if defined(_WINDOWS)
-PUBLIC RETCODE odbc_get_stmt_attr (ODBC_STATEMENT * stmt,
-           long attr,
-           void *value_ptr,
-           long buffer_length, long *length_ptr);
+PUBLIC RETCODE odbc_get_stmt_attr (ODBC_STATEMENT *stmt,
+				   long attr,
+				   void *value_ptr,
+				   long buffer_length, long *length_ptr);
 #else
-PUBLIC RETCODE odbc_get_stmt_attr (ODBC_STATEMENT * stmt,
-           long attr,
-           SQLPOINTER value_ptr,
-           SQLINTEGER buffer_length, SQLINTEGER *length_ptr);
+PUBLIC RETCODE odbc_get_stmt_attr (ODBC_STATEMENT *stmt,
+				   long attr,
+				   SQLPOINTER value_ptr,
+				   SQLINTEGER buffer_length, SQLINTEGER *length_ptr);
 #endif
-PUBLIC RETCODE odbc_set_cursor_name (ODBC_STATEMENT * stmt,
-             char *cursor_name, short name_length);
-PUBLIC RETCODE odbc_get_cursor_name (ODBC_STATEMENT * stmt,
-             SQLCHAR * cursor_name,
-             SQLSMALLINT buffer_length,
-             SQLLEN * name_length_ptr);
-PUBLIC RETCODE odbc_bind_parameter (ODBC_STATEMENT * stmt,
-            SQLUSMALLINT parameter_num,
-            SQLSMALLINT input_output_type,
-            SQLSMALLINT value_type,
-            SQLSMALLINT parameter_type,
-            SQLULEN column_size,
-            SQLSMALLINT decimal_digits,
-            SQLPOINTER parameter_value_ptr,
-            SQLLEN buffer_length,
-            SQLLEN * strlen_ind_ptr);
-PUBLIC RETCODE odbc_num_params (ODBC_STATEMENT * stmt,
-        short *parameter_count);
-PUBLIC RETCODE odbc_prepare (ODBC_STATEMENT * stmt, char *statement_text);
-PUBLIC RETCODE odbc_execute (ODBC_STATEMENT * stmt);
-PUBLIC RETCODE odbc_param_data (ODBC_STATEMENT * stmt, void **valueptr_ptr);
-PUBLIC RETCODE odbc_put_data (ODBC_STATEMENT * stmt,
-            void *data_ptr, SQLLEN strlen_or_ind);
-PUBLIC RETCODE odbc_close_cursor (ODBC_STATEMENT * stmt);
-PUBLIC RETCODE odbc_close_statement (ODBC_STATEMENT * stmt);
-PUBLIC RETCODE odbc_cancel (ODBC_STATEMENT * stmt);
-PUBLIC RETCODE odbc_bulk_operations (ODBC_STATEMENT * stmt, short pperation);
-PUBLIC RETCODE odbc_set_pos (ODBC_STATEMENT * stmt,
-           SQLSETPOSIROW row_number,
-           SQLUSMALLINT operation, SQLUSMALLINT lock_type);
-PUBLIC void free_column_data (COLUMN_DATA * data, int option);
-PUBLIC void reset_result_set (ODBC_STATEMENT * stmt);
-PUBLIC void create_ird (ODBC_STATEMENT * stmt, T_CCI_COL_INFO * cci_col_info,
-      int column_number);
+PUBLIC RETCODE odbc_set_cursor_name (ODBC_STATEMENT *stmt,
+				     char *cursor_name, short name_length);
+PUBLIC RETCODE odbc_get_cursor_name (ODBC_STATEMENT *stmt,
+				     SQLCHAR *cursor_name,
+				     SQLSMALLINT buffer_length,
+				     SQLLEN *name_length_ptr);
+PUBLIC RETCODE odbc_bind_parameter (ODBC_STATEMENT *stmt,
+				    SQLUSMALLINT parameter_num,
+				    SQLSMALLINT input_output_type,
+				    SQLSMALLINT value_type,
+				    SQLSMALLINT parameter_type,
+				    SQLULEN column_size,
+				    SQLSMALLINT decimal_digits,
+				    SQLPOINTER parameter_value_ptr,
+				    SQLLEN buffer_length,
+				    SQLLEN *strlen_ind_ptr);
+PUBLIC RETCODE odbc_num_params (ODBC_STATEMENT *stmt,
+				short *parameter_count);
+PUBLIC RETCODE odbc_prepare (ODBC_STATEMENT *stmt, char *statement_text);
+PUBLIC RETCODE odbc_execute (ODBC_STATEMENT *stmt);
+PUBLIC RETCODE odbc_param_data (ODBC_STATEMENT *stmt, void **valueptr_ptr);
+PUBLIC RETCODE odbc_put_data (ODBC_STATEMENT *stmt,
+			      void *data_ptr, SQLLEN strlen_or_ind);
+PUBLIC RETCODE odbc_close_cursor (ODBC_STATEMENT *stmt);
+PUBLIC RETCODE odbc_close_statement (ODBC_STATEMENT *stmt);
+PUBLIC RETCODE odbc_cancel (ODBC_STATEMENT *stmt);
+PUBLIC RETCODE odbc_bulk_operations (ODBC_STATEMENT *stmt, short pperation);
+PUBLIC RETCODE odbc_set_pos (ODBC_STATEMENT *stmt,
+			     SQLSETPOSIROW row_number,
+			     SQLUSMALLINT operation, SQLUSMALLINT lock_type);
+PUBLIC void free_column_data (COLUMN_DATA *data, int option);
+PUBLIC void reset_result_set (ODBC_STATEMENT *stmt);
+PUBLIC void create_ird (ODBC_STATEMENT *stmt, T_CCI_COL_INFO *cci_col_info,
+			int column_number);
 
 #endif /* ! __ODBC_STMT_HEADER */

--- a/odbc_statement.h
+++ b/odbc_statement.h
@@ -237,6 +237,7 @@ PUBLIC RETCODE odbc_param_data (ODBC_STATEMENT * stmt, void **valueptr_ptr);
 PUBLIC RETCODE odbc_put_data (ODBC_STATEMENT * stmt,
             void *data_ptr, SQLLEN strlen_or_ind);
 PUBLIC RETCODE odbc_close_cursor (ODBC_STATEMENT * stmt);
+PUBLIC RETCODE odbc_close_statement (ODBC_STATEMENT * stmt);
 PUBLIC RETCODE odbc_cancel (ODBC_STATEMENT * stmt);
 PUBLIC RETCODE odbc_bulk_operations (ODBC_STATEMENT * stmt, short pperation);
 PUBLIC RETCODE odbc_set_pos (ODBC_STATEMENT * stmt,

--- a/odbc_type.c
+++ b/odbc_type.c
@@ -1651,8 +1651,8 @@ cci_value_to_odbc (void *c_value, short concise_type,
       bc_num num1 = NULL, num2 = NULL, quot = NULL, rem = NULL, res_tmp = NULL;
       char *pt, *pt2, *tmp_str_num = NULL;
       char str[64];		/* numeric value that is removed a period
-			       * cf) The max precision of numeric is 38 in CUBRID
-			       */
+			   * cf) The max precision of numeric is 38 in CUBRID
+			   */
       short i;
       int num_add_zero = 0;
 

--- a/odbc_type.c
+++ b/odbc_type.c
@@ -1650,9 +1650,7 @@ cci_value_to_odbc (void *c_value, short concise_type,
     {
       bc_num num1 = NULL, num2 = NULL, quot = NULL, rem = NULL, res_tmp = NULL;
       char *pt, *pt2, *tmp_str_num = NULL;
-      char str[64];		/* numeric value that is removed a period
-			   * cf) The max precision of numeric is 38 in CUBRID
-			   */
+      char str[64];		// numeric value that is removed a period. cf) The max precision of numeric is 38 in CUBRID
       short i;
       int num_add_zero = 0;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1059

Purpose
Fixed 'execute' behavior for ODBC Interface in other languages (PHP, PDO and Etc.)

Implement
- Modify the behavior of SQLFreeStmt(StatementHandel, SQL_CLOSE) and SQLCloseCursor to close only Cursors
- Added Testcase in UnitTest-CPP

Remarks
N/A
