### PR TITLE
[APIS-1057] Data type value is returned incorrectly in SQLDescribeColW.

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1315,7 +1315,10 @@ public:
       retcode = SQLAllocHandle (SQL_HANDLE_ENV, SQL_NULL_HANDLE, &hEnv);
       retcode = SQLSetEnvAttr (hEnv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, 0);
       retcode = SQLAllocHandle (SQL_HANDLE_DBC, hEnv, &hDbc);
-      retcode = SQLConnect (hDbc, L"CUBRID Driver Unicode", SQL_NTS, L"dba", SQL_NTS, L"", SQL_NTS);
+      retcode = SQLDriverConnect (hDbc, NULL,
+				  L"DRIVER=CUBRID Driver Unicode;DB_NAME=demodb;SERVER=test-db-server;PORT=33000;UID=dba;PWD=;CHARSET=MS949",
+				  SQL_NTS, NULL, 0, NULL, SQL_DRIVER_NOPROMPT);
+
       Assert::AreNotEqual ((int)retcode, SQL_ERROR);
       retcode = SQLAllocHandle (SQL_HANDLE_STMT, hDbc, &hStmt);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1057

Purpose
QA 테스트 문제 이슈 수정

Implement
- APIS-1053의 Testcase를 수정합니다.

Remarks
charset에 의한 의도된 동작으로 판단되며,
DSN charset에 의한 답안지 문제로 charset을 case에서 설정하도록 추가합니다.
