### PR TITLE
[APIS-1075] Error handling SQLCloseCursor, SQLFreeStmt(SQL_CLOSE) for ruby-odbc

### DIFF
--- a/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
+++ b/UnitTest-CPP/UnitTest-CPP/UnitTest.cpp
@@ -1523,13 +1523,15 @@ public:
 
       retcode = SQLFreeStmt (hStmt, SQL_CLOSE);
       Assert::AreNotEqual ((int)retcode, SQL_ERROR);
+
       retcode = SQLCloseCursor (hStmt);
-      Assert::AreEqual ((int)retcode, SQL_ERROR);
+      Assert::AreEqual ((int)retcode, SQL_SUCCESS_WITH_INFO);
+
       SQLWCHAR Sqlstate[1024] = { 0, };
       retcode = SQLGetDiagRec (SQL_HANDLE_STMT, hStmt, 1, Sqlstate, NULL, NULL, NULL, NULL);
-      Assert::AreNotEqual ((int)retcode, SQL_ERROR);
       wsprintf (wmsg, L"Sqlstate %s", Sqlstate);
       Assert::AreEqual (Sqlstate, L"HY000");
+
       retcode = SQLDisconnect (hDbc);
       retcode = SQLFreeHandle (SQL_HANDLE_DBC, hDbc);
       retcode = SQLFreeHandle (SQL_HANDLE_ENV, hEnv);

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+SHELL_DIR=$(pwd)
+BUILD_DIR=$(pwd)/build
+CCI_BUILD_DIR=$(pwd)/cci-src/build_x86_64_release
+DRIVER_INSTALL_DIR=
+
+echo "SHELL_DIR: $SHELL_DIR"
+echo "BUILD_DIR: $BUILD_DIR"
+echo "DRIVER_INSTALL_DIR: $DRIVER_INSTALL_DIR"
+
+if [ -d "$CCI_BUILD_DIR" ]; then
+    rm -rf "$CCI_BUILD_DIR"
+fi
+
+if [ -d "$BUILD_DIR" ]; then
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+fi
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+if [ "$1" = "debug" ]; then
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
+else
+    cmake ..
+fi
+
+make
+
+if [ -n "$DRIVER_INSTALL_DIR" ]; then
+    cp -rfv $BUILD_DIR/libcascci.* "$DRIVER_INSTALL_DIR"
+    cp -rfv $BUILD_DIR/libcubrid*.* "$DRIVER_INSTALL_DIR"
+fi
+cd "$SHELL_DIR"

--- a/odbc_statement.c
+++ b/odbc_statement.c
@@ -1840,6 +1840,10 @@ odbc_close_cursor (ODBC_STATEMENT *stmt)
       if (cci_rc != CCI_ER_NO_ERROR)
 	{
 	  odbc_set_diag_by_cci (stmt->diag, cci_rc, &cci_err_buf);
+	  if (cci_rc == CCI_ER_RESULT_SET_CLOSED)
+	    {
+	      return ODBC_SUCCESS_WITH_INFO;
+	    }
 	  return ODBC_ERROR;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/projects/APIS/issues/APIS-1075

Purpose
ruby-odbc 동작 체크 중 ODBC 사양과 맞지 않는 부분이 있어 오류가 발생되어 수정합니다.
수정 내용은 SQLCloseCursor에서 result가 close 상태더라도 ERROR를 반환하지 않고 SUCCESS_WITH_INFO를 반환 하도록 수정합니다.

Implement
- changed return value of result close in odbc_close_cursor

Remark
Linux Test 및 build 용 script도 추가합니다.